### PR TITLE
user decay file Bs_phiphi_4K.dec 

### DIFF
--- a/Bs_phiphi_4K.dec
+++ b/Bs_phiphi_4K.dec
@@ -1,0 +1,38 @@
+# $Id: Bs_Jpsiphi_mumuKK.dec,v 1.1 2009/04/27 19:06:47 yarba Exp $
+#
+# This is the decay file for the decay BS0 -> PSI(-> MU+ MU-) PHI(-> K+ K-)
+#
+# EventType: 13144001
+#
+# Descriptor: [B_s0 -> (phi(1020) -> K+ K-) (phi(1020) -> K+ K-)]cc
+#
+# NickName: Bs_phiphi,mm=CPV
+#
+# Physics: Includes radiative mode, CP violation, different lifetimes
+#
+#
+Define Hp 0.49
+Define Hz 0.775
+Define Hm 0.4
+Define pHp 2.50
+Define pHz 0.0
+Define pHm -0.17
+#
+Alias      MyB_s0   B_s0
+Alias      Myanti-B_s0   anti-B_s0
+ChargeConj Myanti-B_s0   MyB_s0
+Alias      MyPhi    phi
+ChargeConj MyPhi    MyPhi
+#
+Decay MyB_s0
+  1.000         MyPhi      MyPhi        PVV_CPLH 0.02 1 Hp pHp Hz pHz Hm pHm;
+#
+Enddecay
+Decay Myanti-B_s0
+  1.000         MyPhi      MyPhi        PVV_CPLH 0.02 1 Hp pHp Hz pHz Hm pHm;
+Enddecay
+#
+Decay MyPhi
+  1.000         K+          K-           VSS;
+Enddecay
+End


### PR DESCRIPTION
The file only presents under CMSSW_6_2_X_SLHC. However, it is also needed for Phase-II tracker requests in 8_2_X release. Please merge.