### PR TITLE
added new pdl files for Bs modified lifetime w comments

### DIFF
--- a/evt_Bsmm40.pdl
+++ b/evt_Bsmm40.pdl
@@ -1,6 +1,7 @@
 *---------------------------------------------------------------------------------------------------------------------------------------
 * 5/10/2013 Updated by R. Godang. The format and convention are based on the current evt.pdl and PDG 2012
 * 2017/11/14 ursl: modified BsH,L (and for completeness also Bs and Bsbar) to lifetime = 4.82366e-1 (1.609e-12sec, from PDG2017)
+* 2021/05/12 ckar: special kind of MC for BsToMuMu with different generated lifetime, modified BsH,L to lifetime = 4.1970900e-01 (1.40e-12sec)
 *---------------------------------------------------------------------------------------------------------------------------------------
 *                  name                  id      mass/GeV    width/GeV     max_Dm/GeV    3*charge   2*spin    lifetime*c/mm    PythiaId
 add  p Particle  K_4*+                            329  2.0450000e+00  1.9800000e-01  2.0000000e-01     3     8  0.0000000e+00          0

--- a/evt_Bsmm45.pdl
+++ b/evt_Bsmm45.pdl
@@ -1,6 +1,7 @@
 *---------------------------------------------------------------------------------------------------------------------------------------
 * 5/10/2013 Updated by R. Godang. The format and convention are based on the current evt.pdl and PDG 2012
 * 2017/11/14 ursl: modified BsH,L (and for completeness also Bs and Bsbar) to lifetime = 4.82366e-1 (1.609e-12sec, from PDG2017)
+* 2021/05/12 ckar: special kind of MC for BsToMuMu with different generated lifetime, modified BsH,L to lifetime = 4.3469900e-01 (1.45e-12sec)
 *---------------------------------------------------------------------------------------------------------------------------------------
 *                  name                  id      mass/GeV    width/GeV     max_Dm/GeV    3*charge   2*spin    lifetime*c/mm    PythiaId
 add  p Particle  K_4*+                            329  2.0450000e+00  1.9800000e-01  2.0000000e-01     3     8  0.0000000e+00          0

--- a/evt_Bsmm50.pdl
+++ b/evt_Bsmm50.pdl
@@ -1,6 +1,7 @@
 *---------------------------------------------------------------------------------------------------------------------------------------
 * 5/10/2013 Updated by R. Godang. The format and convention are based on the current evt.pdl and PDG 2012
 * 2017/11/14 ursl: modified BsH,L (and for completeness also Bs and Bsbar) to lifetime = 4.82366e-1 (1.609e-12sec, from PDG2017)
+* 2021/05/12 ckar: special kind of MC for BsToMuMu with different generated lifetime, modified BsH,L to lifetime = 4.4968900e-01 (1.50e-12sec)
 *---------------------------------------------------------------------------------------------------------------------------------------
 *                  name                  id      mass/GeV    width/GeV     max_Dm/GeV    3*charge   2*spin    lifetime*c/mm    PythiaId
 add  p Particle  K_4*+                            329  2.0450000e+00  1.9800000e-01  2.0000000e-01     3     8  0.0000000e+00          0

--- a/evt_Bsmm55.pdl
+++ b/evt_Bsmm55.pdl
@@ -1,6 +1,7 @@
 *---------------------------------------------------------------------------------------------------------------------------------------
 * 5/10/2013 Updated by R. Godang. The format and convention are based on the current evt.pdl and PDG 2012
 * 2017/11/14 ursl: modified BsH,L (and for completeness also Bs and Bsbar) to lifetime = 4.82366e-1 (1.609e-12sec, from PDG2017)
+* 2021/05/12 ckar: special kind of MC for BsToMuMu with different generated lifetime, modified BsH,L to lifetime = 4.6467800e-01 (1.55e-12sec)
 *---------------------------------------------------------------------------------------------------------------------------------------
 *                  name                  id      mass/GeV    width/GeV     max_Dm/GeV    3*charge   2*spin    lifetime*c/mm    PythiaId
 add  p Particle  K_4*+                            329  2.0450000e+00  1.9800000e-01  2.0000000e-01     3     8  0.0000000e+00          0

--- a/evt_Bsmm60.pdl
+++ b/evt_Bsmm60.pdl
@@ -1,6 +1,7 @@
 *---------------------------------------------------------------------------------------------------------------------------------------
 * 5/10/2013 Updated by R. Godang. The format and convention are based on the current evt.pdl and PDG 2012
 * 2017/11/14 ursl: modified BsH,L (and for completeness also Bs and Bsbar) to lifetime = 4.82366e-1 (1.609e-12sec, from PDG2017)
+* 2021/05/12 ckar: special kind of MC for BsToMuMu with different generated lifetime, modified BsH,L to lifetime = 4.7966800e-01 (1.60e-12sec)
 *---------------------------------------------------------------------------------------------------------------------------------------
 *                  name                  id      mass/GeV    width/GeV     max_Dm/GeV    3*charge   2*spin    lifetime*c/mm    PythiaId
 add  p Particle  K_4*+                            329  2.0450000e+00  1.9800000e-01  2.0000000e-01     3     8  0.0000000e+00          0

--- a/evt_Bsmm65.pdl
+++ b/evt_Bsmm65.pdl
@@ -1,6 +1,7 @@
 *---------------------------------------------------------------------------------------------------------------------------------------
 * 5/10/2013 Updated by R. Godang. The format and convention are based on the current evt.pdl and PDG 2012
 * 2017/11/14 ursl: modified BsH,L (and for completeness also Bs and Bsbar) to lifetime = 4.82366e-1 (1.609e-12sec, from PDG2017)
+* 2021/05/12 ckar: special kind of MC for BsToMuMu with different generated lifetime, modified BsH,L to lifetime = 4.9465800e-01 (1.65e-12sec)
 *---------------------------------------------------------------------------------------------------------------------------------------
 *                  name                  id      mass/GeV    width/GeV     max_Dm/GeV    3*charge   2*spin    lifetime*c/mm    PythiaId
 add  p Particle  K_4*+                            329  2.0450000e+00  1.9800000e-01  2.0000000e-01     3     8  0.0000000e+00          0

--- a/evt_Bsmm70.pdl
+++ b/evt_Bsmm70.pdl
@@ -1,6 +1,7 @@
 *---------------------------------------------------------------------------------------------------------------------------------------
 * 5/10/2013 Updated by R. Godang. The format and convention are based on the current evt.pdl and PDG 2012
 * 2017/11/14 ursl: modified BsH,L (and for completeness also Bs and Bsbar) to lifetime = 4.82366e-1 (1.609e-12sec, from PDG2017)
+* 2021/05/12 ckar: special kind of MC for BsToMuMu with different generated lifetime, modified BsH,L to lifetime = 5.0964700e-01 (1.70e-12sec)
 *---------------------------------------------------------------------------------------------------------------------------------------
 *                  name                  id      mass/GeV    width/GeV     max_Dm/GeV    3*charge   2*spin    lifetime*c/mm    PythiaId
 add  p Particle  K_4*+                            329  2.0450000e+00  1.9800000e-01  2.0000000e-01     3     8  0.0000000e+00          0

--- a/evt_Bsmm75.pdl
+++ b/evt_Bsmm75.pdl
@@ -1,6 +1,7 @@
 *---------------------------------------------------------------------------------------------------------------------------------------
 * 5/10/2013 Updated by R. Godang. The format and convention are based on the current evt.pdl and PDG 2012
 * 2017/11/14 ursl: modified BsH,L (and for completeness also Bs and Bsbar) to lifetime = 4.82366e-1 (1.609e-12sec, from PDG2017)
+* 2021/05/12 ckar: special kind of MC for BsToMuMu with different generated lifetime, modified BsH,L to lifetime = 5.2463700e-01 (1.75e-12sec)
 *---------------------------------------------------------------------------------------------------------------------------------------
 *                  name                  id      mass/GeV    width/GeV     max_Dm/GeV    3*charge   2*spin    lifetime*c/mm    PythiaId
 add  p Particle  K_4*+                            329  2.0450000e+00  1.9800000e-01  2.0000000e-01     3     8  0.0000000e+00          0

--- a/evt_Bsmm80.pdl
+++ b/evt_Bsmm80.pdl
@@ -1,6 +1,7 @@
 *---------------------------------------------------------------------------------------------------------------------------------------
 * 5/10/2013 Updated by R. Godang. The format and convention are based on the current evt.pdl and PDG 2012
 * 2017/11/14 ursl: modified BsH,L (and for completeness also Bs and Bsbar) to lifetime = 4.82366e-1 (1.609e-12sec, from PDG2017)
+* 2021/05/12 ckar: special kind of MC for BsToMuMu with different generated lifetime, modified BsH,L to lifetime = 5.3962600e-01 (1.80e-12sec)
 *---------------------------------------------------------------------------------------------------------------------------------------
 *                  name                  id      mass/GeV    width/GeV     max_Dm/GeV    3*charge   2*spin    lifetime*c/mm    PythiaId
 add  p Particle  K_4*+                            329  2.0450000e+00  1.9800000e-01  2.0000000e-01     3     8  0.0000000e+00          0


### PR DESCRIPTION
I'm adding new pdl files with Bs modified lifetime needed by B->MuMu analysis group for the central production of Bs->MuMu samples. I'm adding the same pdl file added in this PR [1]. Some comments on the pdl files have been added in order to better clarify the differences with evt_2014.pdl and help future users.

[1] https://github.com/cms-data/GeneratorInterface-EvtGenInterface/pull/18